### PR TITLE
Force type to symbol

### DIFF
--- a/app/helpers/alertify_helper.rb
+++ b/app/helpers/alertify_helper.rb
@@ -4,9 +4,10 @@ module AlertifyHelper
   def alertify_flash
     jsReturn = javascript_tag()
     flash.each do |type, message|
+      type = type.to_sym
       # Skip empty messages, e.g. for devise messages set to nothing in a locale file.
       next if message.blank?
-      
+
       type = :success if type == :notice
       type = :error   if type == :alert
       next unless ALERT_TYPES.include?(type)

--- a/app/helpers/alertify_helper.rb
+++ b/app/helpers/alertify_helper.rb
@@ -4,7 +4,7 @@ module AlertifyHelper
   def alertify_flash
     jsReturn = javascript_tag()
     flash.each do |type, message|
-      type = type.to_sym
+      type = type.to_sym unless type.nil?
       # Skip empty messages, e.g. for devise messages set to nothing in a locale file.
       next if message.blank?
 


### PR DESCRIPTION
Not sure if anyone else was having this issue, i'm on rails 4.2.3 and wasn't getting any notifications, traced it to a string being passed in as type, forced to sym and works fine for me now.
